### PR TITLE
Updated rebar config script so it doesn't throw errors on compilation

### DIFF
--- a/rebar.config.script
+++ b/rebar.config.script
@@ -1,11 +1,19 @@
-{ok, VSN} = application:get_key(rebar, vsn),
-[Major|_] = string:tokens(VSN, "."),
+IsRebar3OrMix = case application:get_env(rebar, vsn) of
+    {ok, VSN} ->
+      [Major|_] = string:tokens(VSN, "."),
+      (list_to_integer(Major) >= 3);
+
+    undefined ->
+      %% mix is used?
+      lists:keymember(mix, 1, application:loaded_applications())
+  end,
+
 GitDeps =
     [ {base64url, ".*", {git, "https://github.com/dvv/base64url", {tag, "v1.0"}}}
     , {jsx, ".*", {git, "https://github.com/talentdeficit/jsx", {tag, "2.8.0"}}}
     ],
 
-case list_to_integer(Major) of
-    3 -> CONFIG;
-    _ -> lists:keyreplace(deps, 1, CONFIG, {deps, GitDeps})
+case IsRebar3OrMix of
+  true -> CONFIG;
+  _ -> lists:keyreplace(deps, 1, CONFIG, {deps, GitDeps})
 end.


### PR DESCRIPTION
Hi mate. This one is to get rid of compilation-time warnings when using with Mix.