### PR TITLE
Removed optional alg parameter.

### DIFF
--- a/src/jwk.erl
+++ b/src/jwk.erl
@@ -26,7 +26,6 @@ encode(Id, #'RSAPublicKey'{modulus = N, publicExponent = E}) ->
                 #{
                     kid => Id,
                     kty => <<"RSA">>, 
-                    alg => <<"RS256">>, 
                     n   => encode_int(N), 
                     e   => encode_int(E)
                 }
@@ -63,7 +62,7 @@ decode(Id, Json) ->
 decode([]) ->
     {error, not_found};
 
-decode([#{<<"kty">> := <<"RSA">>, <<"alg">> := <<"RS256">>, <<"n">> := N, <<"e">> := E} | _]) ->
+decode([#{<<"kty">> := <<"RSA">>, <<"n">> := N, <<"e">> := E} | _]) ->
     {ok, 
         #'RSAPublicKey'{
             modulus        = decode_int(N), 

--- a/test/jwk_tests.erl
+++ b/test/jwk_tests.erl
@@ -30,7 +30,6 @@ test_decoding() ->
     {ok, Json} = file:read_file("./test/jwks.json"),
     {ok, PKey} = jwk:decode(?ID, Json),
     Expected   = public(),
-
     ?assertMatch(Expected, PKey).
 
 

--- a/test/jwks.json
+++ b/test/jwks.json
@@ -4,7 +4,6 @@
          "kty":"RSA",
          "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
          "e":"AQAB",
-         "alg":"RS256",
          "kid":"test"
       }
    ]


### PR DESCRIPTION
Hi Yuri. According to rfc7517 [the alg parameter is optional](https://tools.ietf.org/html/rfc7517#section-4.4) and it being mandatory in the code - particularly for decoding - was causing me issues. This PR simply removed the dependency and works with my keys (in my code from Azure AD - an example [here](https://login.microsoftonline.com/te/fabrikamb2c.onmicrosoft.com/b2c_1_susi/discovery/v2.0/keys) ).

`
4.4.  "alg" (Algorithm) Parameter

   The "alg" (algorithm) parameter identifies the algorithm intended for
   use with the key.  The values used should either be registered in the
   IANA "JSON Web Signature and Encryption Algorithms" registry
   established by [JWA] or be a value that contains a Collision-
   Resistant Name.  The "alg" value is a case-sensitive ASCII string.
   Use of this member is OPTIONAL.
`