### PR TITLE
fix jwt:expiration_to_epoch/1

### DIFF
--- a/src/jwt.erl
+++ b/src/jwt.erl
@@ -13,7 +13,7 @@
 -export([encode/3, encode/4]).
 
 -define(HOUR, 3600).
--define(DAY, 3600 * 60).
+-define(DAY, (?HOUR * 24)).
 
 -type expiration() :: {hourly, non_neg_integer()} | {daily, non_neg_integer()} | non_neg_integer().
 
@@ -263,7 +263,9 @@ epoch() -> erlang:system_time(seconds).
 -spec expiration_to_epoch(Expiration :: expiration()) -> neg_integer().
 %% @private
 expiration_to_epoch(Expiration) ->
-    Ts = epoch(),
+    expiration_to_epoch(Expiration, epoch()).
+
+expiration_to_epoch(Expiration, Ts) ->
     case Expiration of
         {hourly, Expiration0} -> (Ts - (Ts rem ?HOUR)) + Expiration0;
         {daily, Expiration0} -> (Ts - (Ts rem ?DAY)) + Expiration0;

--- a/test/jwt_tests.erl
+++ b/test/jwt_tests.erl
@@ -27,7 +27,9 @@ jwt_test_() -> {setup,
     , fun test_encoding_with_ecdsa/0
     , fun test_decoding_ecdsa_with_public_key/0
     , fun test_decoding_ecdsa_invalid_signature/0
-   ]}.
+
+    , fun test_expiration_to_epoch_when_daily_given/0
+    ]}.
 
 start() -> ok.
 stop(_) -> ok.
@@ -214,6 +216,11 @@ test_decoding_ecdsa_invalid_signature() ->
     >>,
     ?assertMatch({error, invalid_signature},
         jwt:decode(makeToken(Header, Payload, Signature), ecdsa_public_key())).
+
+test_expiration_to_epoch_when_daily_given() ->
+    Now            = 1548616000,
+    BeginningOfDay = 1548547200,
+    ?assertEqual(BeginningOfDay, jwt:expiration_to_epoch({daily, 0}, Now)).
 
 %%
 %% Helpers


### PR DESCRIPTION
There were to bugs

* typo `-define(DAY, 3600 * 60)`. There 24 hours in a day, not 60
* Macros expand by substitution. Thus the code `Ts - (Ts rem ?DAY)` becomes `Ts - (Ts rem 3600 * 24)`.

And due to operator precedence we got unexpected behavior.

This fix changes code the way to conform the original implementation

See https://github.com/kato-im/ejwt/blob/9cae7b5084ba275ba74e1805017a5dc1604bb65d/src/ejwt.erl#L130