### PR TITLE
use semver for vsn in app.src and remove maintainers field since it's depreacted

### DIFF
--- a/src/jwt.app.src
+++ b/src/jwt.app.src
@@ -1,11 +1,10 @@
 {application, jwt,
   [ {description, "Erlang JWT library"}
-  , {vsn, git}
+  , {vsn, "semver"}
   , {registered, []}
   , {applications, [kernel, stdlib, crypto, public_key, jsx, base64url]}
   , {env, []}
 
-  , {maintainers, ["Yuri Artemev", "Peter Hizalev"]}
   , {licenses, ["MIT"]}
   , {links, [{"GitHub", "https://github.com/artemeff/jwt"}]}
  ]}.


### PR DESCRIPTION
with this change travis no longer will fail when trying to deploy package to hex.pm :)